### PR TITLE
align before_ms type with protocol as u64

### DIFF
--- a/src/interfaces/definitions/types.ts
+++ b/src/interfaces/definitions/types.ts
@@ -102,7 +102,7 @@ export interface ProsopoGovernanceStatus extends Enum {
 
 /** @name ProsopoLastCorrectCaptcha */
 export interface ProsopoLastCorrectCaptcha extends Struct {
-  readonly beforeMs: u32;
+  readonly beforeMs: u64;
   readonly dappId: AccountId;
 }
 


### PR DESCRIPTION
fixes #53 

Note that because there is no concept of "TimeStamp" on the polkadotjs types package, a Date is used instead to be more js centric. However, it's easier just to deal with the u64 form of the timestamp, which is all that the timestamp type wraps on the protocol side.